### PR TITLE
Correção dos 7 erros do desafio

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,14 +2,14 @@ FROM node:16
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY package.json ./
 
 RUN npm install
 
 COPY . .
 
 # ERRO 1: Porta exposta incorreta (deveria ser 3000)
-EXPOSE 8080
+EXPOSE 3000
 
 # ERRO 2: Comando de inicialização incorreto (deveria ser "npm start" ou "node index.js")
-CMD ["node", "app.js"]
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: '3.8'
 
 services:
-  mongodb:
+  mongo:
     image: mongo:latest
     ports:
-      - "27018:27017"
+      - "27017:27017"
     volumes:
-      - /tmp/data:/data/db
-  app:
+      - data:/data/db
+  index:
     build: ./app
     ports:
-      - "8080:8080"
+      - "3000:3000"
     depends_on:
-      - mongodb
+      - mongo
     restart: always

--- a/solucao.md
+++ b/solucao.md
@@ -1,0 +1,27 @@
+# ERRO 1: Porta exposta incorreta
+
+# CORREÇÃO (deveria ser 3000)
+
+# ERRO 2: Comando de inicialização incorreto
+
+# CORREÇÃO (deveria ser "npm start" ou "node index.js")
+
+# ERRO 3: Serviço com nome incorreto no docker-compose.
+
+# CORREÇÃO O arquivo está como index.js e o docker-compose está procurando o serviço com o nome de app
+
+# ERRO 4: Portas do serviço do mongodb definida como 27018:27017, quando o correto é 27017:27017
+
+# CORREÇÃO Correto é 27017:27017
+
+# ERRO 5: Serviço do mongodb com nome errado
+
+# CORREÇÃO Nome correto do serviço é "mongo" ao invés de "mongodb" no docker-compose
+
+# ERRO 6: Depends_on com nome errado
+
+# CORREÇÃO Alterar de "mongodb" para "mongo"
+
+# ERRO 7: volumes usando uma pasta que não está criada
+
+# CORREÇÃO solução apagar o /tmp/ presente no comando, assim permitindo que a pasta data seja criada

--- a/solucao.md
+++ b/solucao.md
@@ -1,3 +1,5 @@
+Bruno Pereira dos Santos RA:6324550
+
 # ERRO 1: Porta exposta incorreta
 
 # CORREÇÃO (deveria ser 3000)


### PR DESCRIPTION
# ERRO 1: Porta exposta incorreta

# CORREÇÃO (deveria ser 3000)

# ERRO 2: Comando de inicialização incorreto

# CORREÇÃO (deveria ser "npm start" ou "node index.js")

# ERRO 3: Serviço com nome incorreto no docker-compose.

# CORREÇÃO O arquivo está como index.js e o docker-compose está procurando o serviço com o nome de app

# ERRO 4: Portas do serviço do mongodb definida como 27018:27017, quando o correto é 27017:27017

# CORREÇÃO Correto é 27017:27017

# ERRO 5: Serviço do mongodb com nome errado

# CORREÇÃO Nome correto do serviço é "mongo" ao invés de "mongodb" no docker-compose

# ERRO 6: Depends_on com nome errado

# CORREÇÃO Alterar de "mongodb" para "mongo"

# ERRO 7: volumes usando uma pasta que não está criada

# CORREÇÃO solução apagar o /tmp/ presente no comando, assim permitindo que a pasta data seja criada
