### PR TITLE
Correção dos 7 erros do desafio (Diogo Vieira Amorim/ RA:6324639)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 COPY . .
 
 # ERRO 1: Porta exposta incorreta (deveria ser 3000)
-EXPOSE 8080
+EXPOSE 3000
 
 # ERRO 2: Comando de inicialização incorreto (deveria ser "npm start" ou "node index.js")
-CMD ["node", "app.js"]
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,19 @@ version: '3.8'
 
 services:
   mongodb:
-    image: mongo:latest
+    image: mongodb:latest
     ports:
-      - "27018:27017"
+      - "27017:27017"
     volumes:
-      - /tmp/data:/data/db
+       - mongo-data:/data/db
   app:
     build: ./app
     ports:
-      - "8080:8080"
+      - "3000:3000"
     depends_on:
       - mongodb
-    restart: always
+    environment:
+      - MONGO_URI=mongodb://mongodb:27017/jogo7erros
+    restart: always    
+volumes:
+  mongo-data:


### PR DESCRIPTION
Erros encontrados 
1- portas no  compose diferentes
2- imagem com nome so do mongo ao inves de mongo db
3- volumes incorretos 
4- porta 8080 ao inves de 3000
5- Porta exposta incorreta (deveria ser 3000) no dockerfile
6- comando de inicialização incorreto (deveria ser "npm start" ou "node index.js")
7- faltou achar 

