### PR TITLE
Correção dos 7 erros do desafio

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 COPY . .
 
 # ERRO 1: Porta exposta incorreta (deveria ser 3000)
-EXPOSE 8080
+EXPOSE 3000
 
 # ERRO 2: Comando de inicialização incorreto (deveria ser "npm start" ou "node index.js")
-CMD ["node", "app.js"]
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,27 @@ version: '3.8'
 services:
   mongodb:
     image: mongo:latest
-    ports:
-      - "27018:27017"
+    # Exposição removida 
     volumes:
-      - /tmp/data:/data/db
+      - mongodb-data:/data/db # Definir volume
+    networks: # Adiçao da rede
+      - aula-erros-network
   app:
     build: ./app
     ports:
-      - "8080:8080"
+      - "3000:3000" # Mudança para a porta correta
+    environment: # Variáveis de ambiente pra conexão do mongo
+      - MONGO_URI=mongodb://mongodb:27017/desafio
+      - PORT=3000
     depends_on:
       - mongodb
     restart: always
+    networks: # Adição da rede
+      - aula-erros-network
+
+networks: # Adição da rede
+  aula-erros-network:
+    driver: bridge
+
+volumes: # Definir Volume
+  mongodb-data:

--- a/solucao.md
+++ b/solucao.md
@@ -1,0 +1,39 @@
+# Desafio dos 7 Erros - Docker, Node.js e MongoDB
+
+    Maria Fernanda Trega Pinto
+    RA: 6324656
+
+## Erro 01
+
+    Porta exposta incorreta no Dockerfile era EXPOSE 8080, mas o correto é EXPOSE 3000
+
+## Erro 02
+
+    Comando de inicialização incorreto era CMD ["node", "app.js"], mas como o arquivo "app.js" não existe então não pode ser usado. O correto seria CMD ["npm", "start"]
+
+## Erro 03
+
+    Inclusão da rede personalizada aula-erros-network
+
+## Erro 04
+
+    Definição do volume mongodb-data:/data/db
+
+## Erro 05
+
+    Exposição removida 
+    ports:
+     - "27018:27017"
+
+## Erro 06
+
+    Variáveis de ambiente pra conexão do mongo
+      - MONGO_URI=mongodb://mongodb:27017/desafio
+      - PORT=3000
+
+## Erro 07
+
+    Mudança para a porta correta
+    ports:
+      - "3000:3000" 
+


### PR DESCRIPTION
# Desafio dos 7 Erros - Docker, Node.js e MongoDB

    Maria Fernanda Trega Pinto
    RA: 6324656

## Erro 01

    Porta exposta incorreta no Dockerfile era EXPOSE 8080, mas o correto é EXPOSE 3000

## Erro 02

    Comando de inicialização incorreto era CMD ["node", "app.js"], mas como o arquivo "app.js" não existe então não pode ser usado. O correto seria CMD ["npm", "start"]

## Erro 03

    Inclusão da rede personalizada aula-erros-network

## Erro 04

    Definição do volume mongodb-data:/data/db

## Erro 05

    Exposição removida 
    ports:
     - "27018:27017"

## Erro 06

    Variáveis de ambiente pra conexão do mongo
      - MONGO_URI=mongodb://mongodb:27017/desafio
      - PORT=3000

## Erro 07

    Mudança para a porta correta
    ports:
      - "3000:3000" 